### PR TITLE
Mathematician monad

### DIFF
--- a/PrototypeWithInterface.cabal
+++ b/PrototypeWithInterface.cabal
@@ -35,9 +35,11 @@ library
       Robot.BasicMoveHelpers
       Robot.BasicMoves
       Robot.ExistentialMoves
+      Robot.History
       Robot.HoleExpr
       Robot.Lib
       Robot.LibraryMoves
+      Robot.MathematicianMonad
       Robot.NewBinderIdentifiers
       Robot.Parser
       Robot.Poset

--- a/src/APICode/FunctionCaller.hs
+++ b/src/APICode/FunctionCaller.hs
@@ -25,6 +25,9 @@ performFunctionOnProblemState "" _ = Nothing
 performFunctionOnProblemState str (ProblemState tab state _ _) =
     let (functionToApply:rest) = words str
     in case functionToApply of
+        "undo" -> do
+            [] <- Just rest
+            runMathematician (undo tab) state
         "peelUniversalTarg" -> do
             [exprLoc] <- Just rest
             runMathematician (peelUniversalTarg (read exprLoc :: (BoxNumber, Int)) tab) state

--- a/src/APICode/JSONTypes.hs
+++ b/src/APICode/JSONTypes.hs
@@ -4,6 +4,7 @@ module APICode.JSONTypes where
 
 import Robot.TableauFoundation
 import Robot.AutomationData
+import Robot.MathematicianMonad
 
 import Data.Aeson (FromJSON, ToJSON)
 
@@ -14,10 +15,9 @@ import qualified Data.Text.Internal.Lazy as LT
 type Move = String
 data ProblemState = ProblemState {
       getTab :: Tableau
-    , getAutData :: AutData
+    , getState :: MathematicianState
     , getTabHtml :: LT.Text
-    , getAllowedActions :: [String]
-    , getProofHistory :: [(Tableau, AutData, LT.Text)]}
+    , getAllowedActions :: [String]}
     deriving (Show, Generic, Read)
 
 type Action = String

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -30,25 +30,23 @@ libMain = do
             json testState --change this for an alternative problem, e.g. mTestState
 
         post "/move" $ do
-            ActionState action problemState@(ProblemState tab autData tabHtml allowedActions proofHistory) <- jsonData :: ActionM ActionState
+            ActionState action problemState@(ProblemState tab state tabHtml allowedActions) <- jsonData :: ActionM ActionState
             let result = performFunctionOnProblemState action problemState
             case result of
-                Just (TableauOut newTab) -> json (ProblemState newTab autData (renderHtml $ generateTabHtml $ prettifyTab newTab) allowedActions
-                    ((tab, autData, tabHtml):proofHistory))
-                Just (TabAndAutDataOut newAutData newTab) -> json (
-                    ProblemState newTab newAutData (renderHtml $ generateTabHtml $ prettifyTab newTab) allowedActions
-                    ((tab, autData, tabHtml):proofHistory))
+                Just (newTab, newState) -> json (ProblemState newTab newState
+                    (renderHtml $ generateTabHtml $ prettifyTab newTab) allowedActions)
                 _ -> json problemState
 
         post "/save" $ do
-            problemState@(ProblemState _ _ _ allowedActions proofHistory) <- jsonData :: ActionM ProblemState
+            problemState <- jsonData :: ActionM ProblemState
             liftIO (writeFile "saved_state.txt" (show problemState))
             json problemState
 
-
+{-
 a :: IO (Maybe Tableau)
 a = do
     file <- readFile "saved_state.txt"
-    let ProblemState tab _ _ _ _ = read file
+    let ProblemState tab _ _ _ = read file
     let res = libBackwardReasoning lesserThanTrans tab
     return res
+-}

--- a/src/Robot/BasicMoveHelpers.hs
+++ b/src/Robot/BasicMoveHelpers.hs
@@ -5,6 +5,7 @@ import Robot.Poset
 import Robot.TableauFoundation
 
 import Data.Maybe
+import Control.Monad
 
 -- | Gets an unused InternalName from a QZone
 getNewInternalName :: QZone -> InternalName
@@ -22,12 +23,12 @@ findFreshExNm usedNames = head $ filter (`notElem` usedNames) options
 -- | Gets an ExternalName for a variable being peeled. If the peeled variable
 -- already has a suggested ExternalName and it doesn't conflict with others
 -- then we use that. Otherwise, we find a fresh one
-getNewExternalNamePeel :: Maybe ExternalName -> QZone -> Maybe ExternalName
+getNewExternalNamePeel :: (MonadPlus m) => Maybe ExternalName -> QZone -> m ExternalName
 getNewExternalNamePeel exNm (Poset set rel) = case exNm of
     Just nm -> if nm `elem` (mapMaybe qVarGetExternalName set) then
-            Just $ findFreshExNm (mapMaybe qVarGetExternalName set)
-        else exNm
-    _ -> Just $ findFreshExNm (mapMaybe qVarGetExternalName set)
+            return $ findFreshExNm (mapMaybe qVarGetExternalName set)
+        else return nm
+    _ -> return $ findFreshExNm (mapMaybe qVarGetExternalName set)
 
 
 -- | Adds a hypothesis to a specified Box. Because this is just a helper

--- a/src/Robot/BasicMoveHelpers.hs
+++ b/src/Robot/BasicMoveHelpers.hs
@@ -1,3 +1,13 @@
+{-
+  A lot of the functions here have type (MonadPlus m) => ... -> m (Something)
+  Originally the types where just ... -> Maybe Something
+  The new types are more general, making the functions more versatile
+  If you want you can just think of m being Maybe when you read the code
+  (Maybe is an instance of the MonadPlus type class)
+  The reason for this change is so the functions can be used in the
+  Mathematician monad, which is also an instance of MonadPlus.
+-}
+
 module Robot.BasicMoveHelpers where
 
 import Robot.Lib
@@ -34,221 +44,237 @@ getNewExternalNamePeel exNm (Poset set rel) = case exNm of
 -- | Adds a hypothesis to a specified Box. Because this is just a helper
 -- function in writing moves, not a move itself, I don't use the "Move"
 -- type synonym here.
-addHyp :: BoxNumber -> Expr -> Tableau -> Maybe Tableau
+addHyp :: (MonadPlus m) => BoxNumber -> Expr -> Tableau -> m Tableau
 addHyp boxNumber hyp (Tableau qZone rootBox) = do
     boxZipper <- toBoxNumberFromRoot boxNumber rootBox
     let newZipper = addHypToZipper hyp boxZipper
-    Just $ Tableau qZone (unzipBox newZipper)
+    return $ Tableau qZone (unzipBox newZipper)
 
-addPureTarg :: BoxNumber -> Expr -> Tableau -> Maybe Tableau
+addPureTarg :: (MonadPlus m) => BoxNumber -> Expr -> Tableau -> m Tableau
 addPureTarg boxNumber targ (Tableau qZone rootBox) = do
     boxZipper <- toBoxNumberFromRoot boxNumber rootBox
     let newZipper = addPureTargToZipper targ boxZipper
-    Just $ Tableau qZone (unzipBox newZipper)
+    return $ Tableau qZone (unzipBox newZipper)
 
-addBoxTarg :: BoxNumber -> Box Expr -> Tableau -> Maybe Tableau
+addBoxTarg :: (MonadPlus m) => BoxNumber -> Box Expr -> Tableau -> m Tableau
 addBoxTarg boxNumber boxTarg (Tableau qZone rootBox) = do
     boxZipper <- toBoxNumberFromRoot boxNumber rootBox
     let newZipper = addBoxTargToZipper boxTarg boxZipper
-    Just $ Tableau qZone (unzipBox newZipper)
+    return $ Tableau qZone (unzipBox newZipper)
 
 -- | Repeats addHyp on many arguments in an efficient way
-addHyps :: [(BoxNumber, Expr)] -> Tableau -> Maybe Tableau
+addHyps :: (MonadPlus m) => [(BoxNumber, Expr)] -> Tableau -> m Tableau
 addHyps addSchedule (Tableau qZone rootBox) = do
     (boxRoute, _) <- boxNumbersToDirections addSchedule
     
     let zippedBox = (rootBox, [])
-        followAndAddHyps :: [(BoxNumber, Expr)] -> BoxZipper Expr -> Maybe (BoxZipper Expr)
-        followAndAddHyps [] currentZipper = Just currentZipper
+        followAndAddHyps :: (MonadPlus m) => [(BoxNumber, Expr)] -> BoxZipper Expr ->
+            m (BoxZipper Expr)
+        followAndAddHyps [] currentZipper = return currentZipper
         followAndAddHyps ((direction, hyp):rest) currentZipper = do
             newZipper <- toBoxNumberFromZipper direction currentZipper
-            Just $ addHypToZipper hyp newZipper
+            return $ addHypToZipper hyp newZipper
     
     addedHypsZipper <- followAndAddHyps boxRoute zippedBox
     let newRootBox = unzipBox addedHypsZipper
-    Just $ Tableau qZone newRootBox
+    return $ Tableau qZone newRootBox
 
 
-addPureTargs :: [(BoxNumber, Expr)] -> Tableau -> Maybe Tableau
+addPureTargs :: (MonadPlus m) => [(BoxNumber, Expr)] -> Tableau -> m Tableau
 addPureTargs addSchedule (Tableau qZone rootBox) = do
     (boxRoute, _) <- boxNumbersToDirections addSchedule
     
     let zippedBox = (rootBox, [])
-        followAndAddPureTargs :: [(BoxNumber, Expr)] -> BoxZipper Expr -> Maybe (BoxZipper Expr)
-        followAndAddPureTargs [] currentZipper = Just currentZipper
+        followAndAddPureTargs :: (MonadPlus m) => [(BoxNumber, Expr)] ->
+            BoxZipper Expr -> m (BoxZipper Expr)
+        followAndAddPureTargs [] currentZipper = return currentZipper
         followAndAddPureTargs ((direction, pureTarg):rest) currentZipper = do
             newZipper <- toBoxNumberFromZipper direction currentZipper
-            Just $ addPureTargToZipper pureTarg newZipper
+            return $ addPureTargToZipper pureTarg newZipper
     
     addTargsZipper <- followAndAddPureTargs boxRoute zippedBox
     let newRootBox = unzipBox addTargsZipper
-    Just $ Tableau qZone newRootBox
+    return $ Tableau qZone newRootBox
 
-addBoxTargs :: [(BoxNumber, Box Expr)] -> Tableau -> Maybe Tableau
+addBoxTargs :: (MonadPlus m) => [(BoxNumber, Box Expr)] -> Tableau -> m Tableau
 addBoxTargs addSchedule (Tableau qZone rootBox) = do
     (boxRoute, _) <- boxNumbersToDirections addSchedule
     
     let zippedBox = (rootBox, [])
-        followAndAddBoxTargs :: [(BoxNumber, Box Expr)] -> BoxZipper Expr -> Maybe (BoxZipper Expr)
-        followAndAddBoxTargs [] currentZipper = Just currentZipper
+        followAndAddBoxTargs :: (MonadPlus m) => [(BoxNumber, Box Expr)] ->
+            BoxZipper Expr -> m (BoxZipper Expr)
+        followAndAddBoxTargs [] currentZipper = return currentZipper
         followAndAddBoxTargs ((direction, boxTarg):rest) currentZipper = do
             newZipper <- toBoxNumberFromZipper direction currentZipper
-            Just $ addBoxTargToZipper boxTarg newZipper
+            return $ addBoxTargToZipper boxTarg newZipper
     
     addTargsZipper <- followAndAddBoxTargs boxRoute zippedBox
     let newRootBox = unzipBox addTargsZipper
-    Just $ Tableau qZone newRootBox
+    return $ Tableau qZone newRootBox
 
 
 
 -- | Remove a hypothesis, specified by a BoxNumber and the hyp's index within that box
 -- Maybe because the specified hyp may not exist.
-removeHyp :: (BoxNumber, Int) -> Tableau -> Maybe Tableau
+removeHyp :: (MonadPlus m) => (BoxNumber, Int) -> Tableau -> m Tableau
 removeHyp (boxNumber, hypInd) (Tableau qZone boxes) = do
     boxZipper <- toBoxNumberFromRoot boxNumber boxes
     newBoxZipper <- removeHypFromZipper hypInd boxZipper
-    Just (Tableau qZone (unzipBox newBoxZipper))
+    return (Tableau qZone (unzipBox newBoxZipper))
 
-removeTarg :: (BoxNumber, Int) -> Tableau -> Maybe Tableau
+removeTarg :: (MonadPlus m) => (BoxNumber, Int) -> Tableau -> m Tableau
 removeTarg (boxNumber, targInd) (Tableau qZone boxes) = do
     boxZipper <- toBoxNumberFromRoot boxNumber boxes
     newBoxZipper <- removeTargFromZipper targInd boxZipper
-    Just (Tableau qZone (unzipBox newBoxZipper))
+    return (Tableau qZone (unzipBox newBoxZipper))
 
-removeAllTargs :: BoxNumber -> Tableau -> Maybe Tableau
+removeAllTargs :: (MonadPlus m) => BoxNumber -> Tableau -> m Tableau
 removeAllTargs boxNumber (Tableau qZone boxes) = do
     (Box hyps targs, crumbs) <- toBoxNumberFromRoot boxNumber boxes
-    Just (Tableau qZone (unzipBox (Box hyps [], crumbs)))
+    return (Tableau qZone (unzipBox (Box hyps [], crumbs)))
 
 -- | Helper function to remove the i-th element from a list if it exists
 -- and otherwise return Nothing
-removeFromListMaybe :: [a] -> Int -> Maybe [a]
+removeFromListMaybe :: (MonadPlus m) => [a] -> Int -> m [a]
 removeFromListMaybe l i
-    | i < 0 || i >= length l = Nothing
+    | i < 0 || i >= length l = mzero
     | otherwise = let
         (as, _:bs) = splitAt i l
-        in Just $ as++bs
+        in return $ as++bs
 
 -- | Repeats removeHyp on many arguments in an efficient way
-removeHyps :: [(BoxNumber, Int)] -> Tableau -> Maybe Tableau
+removeHyps :: (MonadPlus m) => [(BoxNumber, Int)] -> Tableau -> m Tableau
 removeHyps removeSchedule tab@(Tableau qZone rootBox) = do
     (orderedRemoveSchedule, _) <- boxNumbersToDirectionsWithInt removeSchedule
     let
-        followAndRemoveHyps :: [(BoxNumber, Int)] -> BoxZipper Expr -> Maybe (BoxZipper Expr)
-        followAndRemoveHyps [] boxZipper = Just boxZipper
+        followAndRemoveHyps :: (MonadPlus m) => [(BoxNumber, Int)] ->
+            BoxZipper Expr -> m (BoxZipper Expr)
+        followAndRemoveHyps [] boxZipper = return boxZipper
         followAndRemoveHyps ((boxNumber, hypInd):rest) boxZipper = do
             (Box hyps targs, crumbs) <- toBoxNumberFromZipper boxNumber boxZipper
             newHyps <- removeFromListMaybe hyps hypInd
             followAndRemoveHyps rest (Box newHyps targs, crumbs)
     finalZipper <- followAndRemoveHyps orderedRemoveSchedule (rootBox, [])
-    Just $ (Tableau qZone (unzipBox finalZipper))
+    return $ (Tableau qZone (unzipBox finalZipper))
 
-removePureTargs :: [(BoxNumber, Int)] -> Tableau -> Maybe Tableau
+removePureTargs :: (MonadPlus m) => [(BoxNumber, Int)] -> Tableau -> m Tableau
 removePureTargs removeSchedule tab@(Tableau qZone rootBox) = do
     (orderedRemoveSchedule, _) <- boxNumbersToDirectionsWithInt removeSchedule
     let
-        followAndRemoveTargs :: [(BoxNumber, Int)] -> BoxZipper Expr -> Maybe (BoxZipper Expr)
-        followAndRemoveTargs [] boxZipper = Just boxZipper
+        followAndRemoveTargs :: (MonadPlus m) => [(BoxNumber, Int)] ->
+            BoxZipper Expr -> m (BoxZipper Expr)
+        followAndRemoveTargs [] boxZipper = return boxZipper
         followAndRemoveTargs ((boxNumber, targInd):rest) boxZipper = do
             (Box hyps targs, crumbs) <- toBoxNumberFromZipper boxNumber boxZipper
-            PureTarg targ <- getFromListMaybe targs targInd
+            targ <- getFromListMaybe targs targInd
+            case targ of
+                PureTarg _ -> return ()
+                _ -> mzero -- Fail if one of the targets is not a Pure target
             newTargs <- removeFromListMaybe targs targInd
             followAndRemoveTargs rest (Box hyps newTargs, crumbs)
     finalZipper <- followAndRemoveTargs orderedRemoveSchedule (rootBox, [])
-    Just $ (Tableau qZone (unzipBox finalZipper))
+    return $ (Tableau qZone (unzipBox finalZipper))
 
-removeBoxTargs :: [(BoxNumber, Int)] -> Tableau -> Maybe Tableau
+removeBoxTargs :: (MonadPlus m) => [(BoxNumber, Int)] -> Tableau -> m Tableau
 removeBoxTargs removeSchedule tab@(Tableau qZone rootBox) = do
     (orderedRemoveSchedule, _) <- boxNumbersToDirectionsWithInt removeSchedule
     let
-        followAndRemoveTargs :: [(BoxNumber, Int)] -> BoxZipper Expr -> Maybe (BoxZipper Expr)
-        followAndRemoveTargs [] boxZipper = Just boxZipper
+        followAndRemoveTargs :: (MonadPlus m) => [(BoxNumber, Int)] ->
+            BoxZipper Expr -> m (BoxZipper Expr)
+        followAndRemoveTargs [] boxZipper = return boxZipper
         followAndRemoveTargs ((boxNumber, targInd):rest) boxZipper = do
             (Box hyps targs, crumbs) <- toBoxNumberFromZipper boxNumber boxZipper
-            BoxTarg targ <- getFromListMaybe targs targInd
+            targ <- getFromListMaybe targs targInd
+            case targ of
+                BoxTarg _ -> return ()
+                _ -> mzero  -- Fail if one of the targets is not a Box target
             newTargs <- removeFromListMaybe targs targInd
             followAndRemoveTargs rest (Box hyps newTargs, crumbs)
     finalZipper <- followAndRemoveTargs orderedRemoveSchedule (rootBox, [])
-    Just $ (Tableau qZone (unzipBox finalZipper))
+    return $ (Tableau qZone (unzipBox finalZipper))
 
 
 -- | Updates the specified hypothesis.
-updateHyp :: (BoxNumber, Int) -> Expr -> Tableau -> Maybe Tableau
+updateHyp :: (MonadPlus m) => (BoxNumber, Int) -> Expr -> Tableau -> m Tableau
 updateHyp (boxNumber, hypInd) newHyp (Tableau qZone rootBox) = do
     boxZipper <- toBoxNumberFromRoot boxNumber rootBox
     newBoxZipper <- updateHypInZipper hypInd newHyp boxZipper
     let newBox = unzipBox newBoxZipper
-    Just (Tableau qZone newBox)
+    return (Tableau qZone newBox)
 
-updatePureTarg :: (BoxNumber, Int) -> Expr -> Tableau -> Maybe Tableau
+updatePureTarg :: (MonadPlus m) => (BoxNumber, Int) -> Expr -> Tableau -> m Tableau
 updatePureTarg (boxNumber, targInd) newTarg (Tableau qZone rootBox) = do
     boxZipper <- toBoxNumberFromRoot boxNumber rootBox
     newBoxZipper <- updatePureTargInZipper targInd newTarg boxZipper
     let newBox = unzipBox newBoxZipper
-    Just (Tableau qZone newBox)
+    return (Tableau qZone newBox)
 
-updateBoxTarg :: (BoxNumber, Int) -> Box Expr -> Tableau -> Maybe Tableau
+updateBoxTarg :: (MonadPlus m) => (BoxNumber, Int) -> Box Expr -> Tableau -> m Tableau
 updateBoxTarg (boxNumber, targInd) newTarg (Tableau qZone rootBox) = do
     boxZipper <- toBoxNumberFromRoot boxNumber rootBox
     newBoxZipper <- updateBoxTargInZipper targInd newTarg boxZipper
     let newBox = unzipBox newBoxZipper
-    Just (Tableau qZone newBox)
+    return (Tableau qZone newBox)
 
 -- | Helper function to get the i-th element from a list if it exists
 -- and return Nothing if not.
-getFromListMaybe :: [a] -> Int -> Maybe a
+getFromListMaybe :: (MonadPlus m) => [a] -> Int -> m a
 getFromListMaybe l i
-    | i < 0 || i >= length l = Nothing
-    | otherwise = Just $ l!!i
+    | i < 0 || i >= length l = mzero
+    | otherwise = return $ l!!i
 
 -- | Gets the specified Hyp
-getHyp :: (BoxNumber, Int) -> Tableau -> Maybe Expr
+getHyp :: (MonadPlus m) => (BoxNumber, Int) -> Tableau -> m Expr
 getHyp (boxNumber, hypInd) (Tableau qZone rootBox) = do
     boxZipper <- toBoxNumberFromRoot boxNumber rootBox
     getHypInZipper hypInd boxZipper
 
-getPureTarg :: (BoxNumber, Int) -> Tableau -> Maybe Expr
+getPureTarg :: (MonadPlus m) => (BoxNumber, Int) -> Tableau -> m Expr
 getPureTarg (boxNumber, targInd) (Tableau qZone rootBox) = do
     boxZipper <- toBoxNumberFromRoot boxNumber rootBox
     getPureTargInZipper targInd boxZipper
 
-getBoxTarg :: (BoxNumber, Int) -> Tableau -> Maybe (Box Expr)
+getBoxTarg :: (MonadPlus m) => (BoxNumber, Int) -> Tableau -> m (Box Expr)
 getBoxTarg (boxNumber, targInd) (Tableau qZone rootBox) = do
     boxZipper <- toBoxNumberFromRoot boxNumber rootBox
     getBoxTargInZipper targInd boxZipper
 
 -- | Efficiently gets the specified list of hyps. Data is stored with each hyp,
 -- and this is preserved. Also returns the deepest BoxNumber from the boxes
-getHypsWithData :: [((BoxNumber, Int), a)] -> Tableau -> Maybe ([(Expr, a)], BoxNumber)
+getHypsWithData :: (MonadPlus m) => [((BoxNumber, Int), a)] -> Tableau ->
+    m ([(Expr, a)], BoxNumber)
 getHypsWithData getSchedule tab@(Tableau qZone rootBox) = do
     let boxNumbersWithData = map (\((boxNumber, hypInd), dat) -> (boxNumber, (hypInd, dat))) getSchedule
     (directions, deepestBox) <- boxNumbersToDirections boxNumbersWithData
     let
-        followAndGetHyps :: [(BoxNumber, (Int, a))] -> BoxZipper Expr -> Maybe [(Expr, a)]
-        followAndGetHyps [] _ = Just []
+        followAndGetHyps :: (MonadPlus m) => [(BoxNumber, (Int, a))] ->
+            BoxZipper Expr -> m [(Expr, a)]
+        followAndGetHyps [] _ = return []
         followAndGetHyps ((boxNumber, (hypInd, dat)):rest) boxZipper = do
             newBoxZipper <- toBoxNumberFromZipper boxNumber boxZipper
             hyp <- getHypInZipper hypInd newBoxZipper
             otherHyps <- followAndGetHyps rest newBoxZipper
-            Just ((hyp, dat):otherHyps)
+            return ((hyp, dat):otherHyps)
     extractedHyps <- followAndGetHyps boxNumbersWithData (rootBox, [])
-    Just (extractedHyps, deepestBox)
+    return (extractedHyps, deepestBox)
 
 -- | As above, but for targs and returns the shallowest (not deepest) BoxNumber.
-getTargsWithData :: [((BoxNumber, Int), a)] -> Tableau -> Maybe ([(Expr, a)], BoxNumber)
+getTargsWithData :: (MonadPlus m) => [((BoxNumber, Int), a)] -> Tableau ->
+    m ([(Expr, a)], BoxNumber)
 getTargsWithData getSchedule tab@(Tableau qZone rootBox) = do
     let boxNumbersWithData = map (\((boxNumber, targInd), dat) -> (boxNumber, (targInd, dat))) getSchedule
     (directions, shallowestBox) <- boxNumbersToDirectionsFlipped boxNumbersWithData
     let
-        followAndGetTargs :: [(BoxNumber, (Int, a))] -> BoxZipper Expr -> Maybe [(Expr, a)]
-        followAndGetTargs [] _ = Just []
+        followAndGetTargs :: (MonadPlus m) => [(BoxNumber, (Int, a))] ->
+            BoxZipper Expr -> m [(Expr, a)]
+        followAndGetTargs [] _ = return []
         followAndGetTargs ((boxNumber, (targInd, dat)):rest) boxZipper = do
             newBoxZipper <- toBoxNumberFromZipper boxNumber boxZipper
             targ <- getPureTargInZipper targInd newBoxZipper
             otherTargs <- followAndGetTargs rest newBoxZipper
-            Just ((targ, dat):otherTargs)
+            return ((targ, dat):otherTargs)
     extractedTargs <- followAndGetTargs boxNumbersWithData (rootBox, [])
-    Just (extractedTargs, shallowestBox)
+    return (extractedTargs, shallowestBox)
 
 -- | Checks if the list of expressions provided exist as hypothess in the tableau
 -- in such a way that they can be used together. If not, returns Nothing.

--- a/src/Robot/BasicMoves.hs
+++ b/src/Robot/BasicMoves.hs
@@ -11,6 +11,7 @@ import Robot.Lib
 import Robot.TableauFoundation
 import Robot.Poset
 import Robot.BasicMoveHelpers
+import Robot.MathematicianMonad
 
 import Control.Monad
 import Data.Maybe

--- a/src/Robot/BasicMoves.hs
+++ b/src/Robot/BasicMoves.hs
@@ -12,7 +12,9 @@ import Robot.TableauFoundation
 import Robot.Poset
 import Robot.BasicMoveHelpers
 import Robot.MathematicianMonad
+import Robot.History
 import Robot.AutomationData
+import Control.Monad.State
 
 import Control.Applicative
 import Control.Monad
@@ -34,6 +36,18 @@ type Move = Tableau -> Mathematician Tableau
 
 
 -- <<< NON-LIB MOVES >>>
+
+-- | Undo move, now easy to implement by using the Mathematician monad
+-- Note: the tableau given to this move has no effect on the result, but is
+-- included so that undo still has type Move. This move fails if there are
+-- no previous entries in the history
+undo :: Move
+undo _ = do
+    MathematicianState freshNm _ history <- get
+    history' <- historyBackInTimeStep history
+    HistoryItem tab autData <- historyPresent history'
+    put $ MathematicianState freshNm autData history'
+    return tab
 
 -- PEELING
 

--- a/src/Robot/BasicMoves.hs
+++ b/src/Robot/BasicMoves.hs
@@ -12,7 +12,9 @@ import Robot.TableauFoundation
 import Robot.Poset
 import Robot.BasicMoveHelpers
 import Robot.MathematicianMonad
+import Robot.AutomationData
 
+import Control.Applicative
 import Control.Monad
 import Data.Maybe
 import Debug.Trace
@@ -26,8 +28,9 @@ import Debug.Trace
 -- and implement that.
 
 
--- | Takes a Tableau and returns an updated Tableau. Maybe because the move could fail.
-type Move = Tableau -> Maybe Tableau
+-- | Takes a Tableau and returns an updated Tableau.
+-- Moves happen inside the Mathematician monad, as defined in MathematicianMonad.hs
+type Move = Tableau -> Mathematician Tableau
 
 
 -- <<< NON-LIB MOVES >>>
@@ -47,7 +50,7 @@ peelUniversalTarg (boxNumber, targInd) tab@(Tableau qZone@(Poset set rel) rootBo
     let newDeps = [(y, peeledVariable) | y <- freeVars, qVarGetQuantifier y == "Exists"] -- We only need to add dependencies relating to exists, because dependencies between forall's is given by this
     newQZone <- addRels (addSetMember qZone peeledVariable) newDeps
     (Tableau _ newRootBox) <- updatePureTarg (boxNumber, targInd) (instantiate (Free peeledName) sc) tab
-    return $ Tableau newQZone newRootBox
+    result $ Tableau newQZone newRootBox
 
 -- | Peels existential target, creating a metavariable
 -- targ i : exists x, P(x)
@@ -62,7 +65,7 @@ peelExistentialTarg (boxNumber, targInd) tab@(Tableau qZone@(Poset set rel) root
     let newDeps = [(y, peeledVariable) | y <- freeVars, qVarGetQuantifier y == "Forall"] -- We only need to add dependencies relating to exists, because dependencies between forall's is given by this
     newQZone <- addRels (addSetMember qZone peeledVariable) newDeps
     (Tableau _ newRootBox) <- updatePureTarg (boxNumber, targInd) (instantiate (Free peeledName) sc) tab
-    return $ Tableau newQZone newRootBox
+    result $ Tableau newQZone newRootBox
 
 -- | Peels existential hypothesis
 -- hyp i : exists x, P(x)
@@ -78,13 +81,19 @@ peelExistentialHyp (boxNumber, hypInd) tab@(Tableau qZone@(Poset set rel) rootBo
     let newDeps = [(y, peeledVariable) | y <- freeVars, qVarGetQuantifier y == "Exists"] -- We only need to add dependencies relating to exists, because dependencies between forall's is given by this
     newQZone <- addRels (addSetMember qZone peeledVariable) newDeps
     (Tableau _ newRootBox) <- updateHyp (boxNumber, hypInd) (instantiate (Free peeledName) sc) tab
-    return $ Tableau newQZone newRootBox
+    result $ Tableau newQZone newRootBox
 
 -- | Peels universal hypothesis, creating a metavariable
 -- This move keeps the original hypothesis, because it's dangerous otherwise
 -- hyp i : forall x, P(x)
 peelUniversalHyp :: (BoxNumber, Int) -> Move
-peelUniversalHyp (boxNumber, hypInd) tab@(Tableau qZone@(Poset set rel) rootBox) = do
+peelUniversalHyp address@(boxNumber, hypInd) tab@(Tableau qZone@(Poset set rel) rootBox) = do
+    autData <- getAutData
+    -- Only proceed if the hypothesis itself hasn't been peeled before.
+    -- In order to override this one can remove the relevant entry from the AutData
+    case getHypID address autData of
+        Nothing -> return ()
+        Just id -> guard $ not $ id `elem` getPeeledUniversalHyps autData
     expr@(Forall exNm sc) <- getHyp (boxNumber, hypInd) tab
     let peeledName = getNewInternalName qZone
     let peeledExternalName = getNewExternalNamePeel exNm qZone
@@ -94,7 +103,8 @@ peelUniversalHyp (boxNumber, hypInd) tab@(Tableau qZone@(Poset set rel) rootBox)
     let newDeps = [(y, peeledVariable) | y <- freeVars, qVarGetQuantifier y == "Forall"] -- We only need to add dependencies relating to exists, because dependencies between forall's is given by this
     newQZone <- addRels (addSetMember qZone peeledVariable) newDeps
     (Tableau _ newRootBox) <- addHyp boxNumber (instantiate (Free peeledName) sc) tab
-    return $ Tableau newQZone newRootBox
+    updateAutData $ addPeeledUniversalHyp address
+    result $ Tableau newQZone newRootBox
 
 
 -- TIDYING
@@ -102,25 +112,26 @@ peelUniversalHyp (boxNumber, hypInd) tab@(Tableau qZone@(Poset set rel) rootBox)
 -- | Tidies implication in target
 -- targ i : P \implies Q
 tidyImplInTarg :: (BoxNumber, Int) -> Move
-tidyImplInTarg (boxNumber, targInd) tab@(Tableau qZone rootBox) = do
+tidyImplInTarg address@(boxNumber, targInd) tab@(Tableau qZone rootBox) = do
     Box hyps targs <- getBox boxNumber rootBox
     PureTarg (Implies p q) <- getFromListMaybe targs targInd
     if length targs == 1 then
-        addHyp boxNumber p tab >>= updatePureTarg (boxNumber, targInd) q
+        addHyp boxNumber p tab >>= updatePureTarg (boxNumber, targInd) q >>= result
     else
-        removeTarg (boxNumber, targInd) tab >>= addBoxTarg boxNumber (Box [p] [PureTarg q])
+        do updateAutData $ applyTracker $ targDeletionTracker address
+           removeTarg (boxNumber, targInd) tab >>= addBoxTarg boxNumber (Box [p] [PureTarg q]) >>= result
 
 -- | Splits and hypotheses up
 -- hyp i : P ^ Q
 tidyAndInHyp :: (BoxNumber, Int) -> Move
 tidyAndInHyp (boxNumber, hypInd) tab@(Tableau qZone rootBox) = do
     And p q <- getHyp (boxNumber, hypInd) tab
-    updateHyp (boxNumber, hypInd) p tab >>= addHyp boxNumber q
+    updateHyp (boxNumber, hypInd) p tab >>= addHyp boxNumber q >>= result
 
 tidyAndInTarg :: (BoxNumber, Int) -> Move
 tidyAndInTarg (boxNumber, targInd) tab@(Tableau qZone rootBox) = do
     And p q <- getPureTarg (boxNumber, targInd) tab
-    updatePureTarg (boxNumber, targInd) p tab >>= addPureTarg boxNumber q
+    updatePureTarg (boxNumber, targInd) p tab >>= addPureTarg boxNumber q >>= result
 
 
 -- MODUS PONENS AND BACKWARDS REASONING
@@ -130,8 +141,17 @@ tidyAndInTarg (boxNumber, targInd) tab@(Tableau qZone rootBox) = do
 -- hyp j : P(y)
 -- conclude : Q(y)
 modusPonens :: (BoxNumber, Int) -> (BoxNumber, Int) -> Move
-modusPonens (boxNumber1, hypInd1) (boxNumber2, hypInd2) tab@(Tableau qZone rootBox) = do
+modusPonens address1@(boxNumber1, hypInd1) address2@(boxNumber2, hypInd2)
+        tab@(Tableau qZone rootBox) = do
     guard $ isPrefix boxNumber1 boxNumber2 || isPrefix boxNumber2 boxNumber1
+    autData <- getAutData
+    -- Only proceed if the pair hasn't been used before.
+    -- In order to override this one can remove the relevant entry from the AutData
+    case getHypID address1 autData of
+        Nothing -> return ()
+        Just id1 -> case getHypID address2 autData of
+            Nothing -> return ()
+            Just id2 -> guard $ not $ (id1, id2) `elem` getModusPonensPairs autData
     let deepestBoxNumber = if isPrefix boxNumber1 boxNumber2 then boxNumber2 else boxNumber1
 
     expr@(Forall exNm (Sc (Implies px qx))) <- getHyp (boxNumber1, hypInd1) tab
@@ -144,21 +164,31 @@ modusPonens (boxNumber1, hypInd1) (boxNumber2, hypInd2) tab@(Tableau qZone rootB
     let successes = filter (\var -> instantiate (Free var) (Sc px) == py) toInstantiate'
     guard $ length successes == 1
     let newHyp = instantiate (Free . head $ successes) (Sc qx)
-    
-    addHyp deepestBoxNumber newHyp tab
+    updateAutData $ addModusPonensPair address1 address2
+    addHyp deepestBoxNumber newHyp tab >>= result
 
 -- | Performs raw modus ponens on hypotheses i and j
 -- hyp i : P \implies Q
 -- hyp j : P
 -- conclude : Q
 rawModusPonens :: (BoxNumber, Int) -> (BoxNumber, Int) -> Move
-rawModusPonens (boxNumber1, hypInd1) (boxNumber2, hypInd2) tab@(Tableau qZone rootBox) = do
+rawModusPonens address1@(boxNumber1, hypInd1) address2@(boxNumber2, hypInd2)
+        tab@(Tableau qZone rootBox) = do
     guard $ isPrefix boxNumber1 boxNumber2 || isPrefix boxNumber2 boxNumber1
+    autData <- getAutData
+    -- Only proceed if the pair hasn't been used before.
+    -- In order to override this one can remove the relevant entry from the AutData
+    case getHypID address1 autData of
+        Nothing -> return ()
+        Just id1 -> case getHypID address2 autData of
+            Nothing -> return ()
+            Just id2 -> guard $ not $ (id1, id2) `elem` getRawModusPonensPairs autData
     let deepestBoxNumber = if isPrefix boxNumber1 boxNumber2 then boxNumber2 else boxNumber1
     expr@(Implies p q) <- getHyp (boxNumber1, hypInd1) tab
     p' <- getHyp (boxNumber2, hypInd2) tab
     guard $ p' == p
-    addHyp deepestBoxNumber q tab
+    updateAutData $ addRawModusPonensPair address1 address2
+    addHyp deepestBoxNumber q tab >>= result
 
 
 -- | Performs backwards reasoning on hypothesis i and target j
@@ -172,21 +202,35 @@ backwardReasoningHyp (boxNumber1, hypInd) (boxNumber2, targInd) tab@(Tableau qZo
     expr@(Implies p q) <- getHyp (boxNumber1, hypInd) tab
     q' <- getPureTarg (boxNumber2, targInd) tab
     guard $ q == q'
-    updatePureTarg (boxNumber2, targInd) p tab
+    updatePureTarg (boxNumber2, targInd) p tab >>= result
 
 
 -- <<< OTHER >>>
+
+-- | Tracker for the nesting that occurs when we commit to a hypothesis.
+-- The way commitToHyp is written, the box always becomes nested at index 1
+trackCommitToHyp :: BoxNumber -> AutData -> AutData
+trackCommitToHyp boxNumber = applyTracker $ nestTracker boxNumber 1
 
 -- | Commits to the use of a particular hypothesis
 -- hyp i : P \implies Q
 -- add a new box with only target P and all hypotheses except i
 -- replace hyp i in this box with Q
 commitToHyp :: (BoxNumber, Int) -> Move
-commitToHyp (boxNumber, hypInd) tab@(Tableau qZone rootBox) = do
+commitToHyp address@(boxNumber, hypInd) tab@(Tableau qZone rootBox) = do
+    autData <- getAutData
+    -- Only proceed if the hypothesis itself hasn't been commited to before.
+    -- In order to override this one can remove the relevant entry from the AutData
+    case getHypID address autData of
+        Nothing -> return ()
+        Just id -> guard $ not $ id `elem` getCommittedToHyps autData
     Implies p q <- getHyp (boxNumber, hypInd) tab
     Box hyps targs <- getBox boxNumber rootBox
     let targsWithQ = Box [q] targs
-    removeAllTargs boxNumber tab >>= addPureTarg boxNumber p >>= addBoxTarg boxNumber targsWithQ
+    updateAutData $ trackCommitToHyp boxNumber
+    updateAutData $ addCommittedToHyp address
+    removeAllTargs boxNumber tab >>= addPureTarg boxNumber p >>=
+        addBoxTarg boxNumber targsWithQ >>= result
 
 
 -- <<< QUALITY OF LIFE MOVES >>>
@@ -218,24 +262,3 @@ getAllTargInds tab@(Tableau qZone rootBox) = let
                 Just newZipper -> getAllTargIndsFromZipper newZipper (boxNumber++[targInd])
                 Nothing -> []) [0..length targs-1]
     in getAllTargIndsFromZipper (rootBox, []) []
-
--- As horrific as this looks, I think laziness means it's not too bad actually
-tidyEverything :: Move
-tidyEverything tab = let
-    repeatOnce :: Move
-    repeatOnce tab' = let
-        allHypInds = getAllHypInds tab'
-        allTargInds = getAllTargInds tab'
-        universalTargPeels = mapMaybe (\i -> peelUniversalTarg i tab') allTargInds
-        existentialHypPeels = mapMaybe (\i -> peelExistentialHyp i tab') allHypInds
-        implPeels = mapMaybe (\i -> tidyImplInTarg i tab') allTargInds
-        andHypPeels = mapMaybe (\i -> tidyAndInHyp i tab') allHypInds
-        andTargPeels = mapMaybe (\i -> tidyAndInTarg i tab') allTargInds
-        concated = universalTargPeels ++ existentialHypPeels ++ implPeels ++
-            andHypPeels ++ andTargPeels
-        in case concated of
-            [] -> Nothing
-            (res:_) -> Just res
-    in case repeatOnce tab of
-        Just newTab -> tidyEverything newTab
-        Nothing -> Just tab

--- a/src/Robot/History.hs
+++ b/src/Robot/History.hs
@@ -8,6 +8,8 @@ import Robot.TableauFoundation
 import GHC.Generics
 import Control.Monad
 
+import Data.Aeson (FromJSON, ToJSON)
+
 -- | History item is a data type storing the relevent information for
 -- our problem state at a given point in time
 data HistoryItem = HistoryItem { getOldTableau :: Tableau,
@@ -21,6 +23,11 @@ infix 5 :=>
 -- Top of the stack should be the present.
 data History = NoHistory | History :=> HistoryItem
     deriving (Show, Read, Generic)
+
+instance ToJSON HistoryItem
+instance ToJSON History
+instance FromJSON HistoryItem
+instance FromJSON History
 
 -- | Remove the top entry in the history, effectively going back in time one step.
 -- Fails if there is no history

--- a/src/Robot/History.hs
+++ b/src/Robot/History.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Robot.History where
+
+import Robot.AutomationData
+import Robot.TableauFoundation
+
+import GHC.Generics
+import Control.Monad
+
+-- | History item is a data type storing the relevent information for
+-- our problem state at a given point in time
+data HistoryItem = HistoryItem { getOldTableau :: Tableau,
+                                getOldAutData :: AutData }
+    deriving (Show, Read, Generic)
+
+infix 5 :=>
+-- | The History is effectively a stack of history items.
+-- Design decision: History includes the present, so that we don't
+-- need to look in two places when doing analysis on present/history.
+-- Top of the stack should be the present.
+data History = NoHistory | History :=> HistoryItem
+    deriving (Show, Read, Generic)
+
+-- | Remove the top entry in the history, effectively going back in time one step.
+-- Fails if there is no history
+historyBackInTimeStep :: (MonadPlus m) => History -> m History
+historyBackInTimeStep NoHistory = mzero
+historyBackInTimeStep (history :=> historyItem) = return history
+
+-- | Returns the top entry in the history, which should be the present.
+-- Fails if there is no history
+historyPresent :: (MonadPlus m) => History -> m HistoryItem
+historyPresent NoHistory = mzero
+historyPresent (history :=> historyItem) = return historyItem

--- a/src/Robot/History.hs
+++ b/src/Robot/History.hs
@@ -16,27 +16,24 @@ data HistoryItem = HistoryItem { getOldTableau :: Tableau,
                                 getOldAutData :: AutData }
     deriving (Show, Read, Generic)
 
-infix 5 :=>
--- | The History is effectively a stack of history items.
+-- | The History is effectively a stack of history items,
+-- implemented as a list.
 -- Design decision: History includes the present, so that we don't
 -- need to look in two places when doing analysis on present/history.
--- Top of the stack should be the present.
-data History = NoHistory | History :=> HistoryItem
-    deriving (Show, Read, Generic)
+-- first should be the present.
+type History = [HistoryItem]
 
 instance ToJSON HistoryItem
-instance ToJSON History
 instance FromJSON HistoryItem
-instance FromJSON History
 
 -- | Remove the top entry in the history, effectively going back in time one step.
 -- Fails if there is no history
 historyBackInTimeStep :: (MonadPlus m) => History -> m History
-historyBackInTimeStep NoHistory = mzero
-historyBackInTimeStep (history :=> historyItem) = return history
+historyBackInTimeStep [] = mzero
+historyBackInTimeStep (historyItem:history) = return history
 
 -- | Returns the top entry in the history, which should be the present.
 -- Fails if there is no history
 historyPresent :: (MonadPlus m) => History -> m HistoryItem
-historyPresent NoHistory = mzero
-historyPresent (history :=> historyItem) = return historyItem
+historyPresent [] = mzero
+historyPresent (historyItem:history) = return historyItem

--- a/src/Robot/HoleExpr.hs
+++ b/src/Robot/HoleExpr.hs
@@ -45,7 +45,7 @@ holeFreeVars (Free n) = Hole n
 holeFreeVars (Con con) = HoleCon con
 holeFreeVars (B i) = HoleB i
 
--- | Takes a holed expression without holes and returns an expression (Maybe because there might be holes)
+-- | Takes a holed expression without holes and returns an expression (MonadPlus because there might be holes)
 holeExprToExpr :: (MonadPlus m) => HoleExpr -> m Expr
 holeExprToExpr (HoleApp e e') = do
     a <- holeExprToExpr e

--- a/src/Robot/HoleExpr.hs
+++ b/src/Robot/HoleExpr.hs
@@ -8,7 +8,7 @@ import Robot.TableauFoundation
 import Robot.PPrinting
 
 import Data.List ( nub )
-
+import Control.Monad
 
 -- | The type of expressions with the addition of variables in the sense of unification.
 data HoleExpr
@@ -46,7 +46,7 @@ holeFreeVars (Con con) = HoleCon con
 holeFreeVars (B i) = HoleB i
 
 -- | Takes a holed expression without holes and returns an expression (Maybe because there might be holes)
-holeExprToExpr :: HoleExpr -> Maybe Expr
+holeExprToExpr :: (MonadPlus m) => HoleExpr -> m Expr
 holeExprToExpr (HoleApp e e') = do
     a <- holeExprToExpr e
     b <- holeExprToExpr e'
@@ -54,10 +54,10 @@ holeExprToExpr (HoleApp e e') = do
 holeExprToExpr (HoleAbs exNm (HoleSc sc)) = do
     a <- holeExprToExpr sc
     return $ Abs exNm (Sc a)
-holeExprToExpr (HoleFree n) = Just $ Free n
-holeExprToExpr (HoleCon con) = Just $ Con con
-holeExprToExpr (HoleB i) = Just $ B i
-holeExprToExpr (Hole _) = Nothing
+holeExprToExpr (HoleFree n) = return $ Free n
+holeExprToExpr (HoleCon con) = return $ Con con
+holeExprToExpr (HoleB i) = return $ B i
+holeExprToExpr (Hole _) = mzero
 
 
 -- IMPROVEMENT - probably change to HashMap later, but will keep as list for now
@@ -65,31 +65,31 @@ type Substitution = [(InternalName, Expr)]
 
 -- Add a single assignment to a substitution. Maybe because consistency
 -- could fail
-addAssignment :: Substitution -> (InternalName, Expr) -> Maybe Substitution
+addAssignment :: (MonadPlus m) => Substitution -> (InternalName, Expr) -> m Substitution
 addAssignment sub (i, expr) = case lookup i sub of
-    Nothing -> Just ((i, expr):sub)
-    Just expr' -> if expr == expr' then Just sub else Nothing
+    Nothing -> return ((i, expr):sub)
+    Just expr' -> if expr == expr' then return sub else mzero
 
 -- | Check that all InternalNames map to things which agree, then union
 -- (there are more efficient ways to do this, of course)
-mergeSubstitutions :: Substitution -> Substitution -> Maybe Substitution
+mergeSubstitutions :: (MonadPlus m) => Substitution -> Substitution -> m Substitution
 mergeSubstitutions s1 s2 = 
     let attempt = nub (s1 ++ s2)
         agree = map fst attempt == nub (map fst attempt)
-    in if agree then Just attempt else Nothing
+    in if agree then return attempt else mzero
 
 -- | Asks if we can get the second expression from the first by substituting terms for holes correctly.
-matchExpressions :: HoleExpr -> Expr -> Maybe Substitution
+matchExpressions :: (MonadPlus m) => HoleExpr -> Expr -> m Substitution
 matchExpressions (HoleApp e1 e2) (App e1' e2') = do
     sub1 <- matchExpressions e1 e1'
     sub2 <- matchExpressions e2 e2'
     mergeSubstitutions sub1 sub2
 matchExpressions (HoleAbs _ (HoleSc sc1)) (Abs _ (Sc sc2)) = matchExpressions sc1 sc2
-matchExpressions (HoleCon s) (Con s') = if s == s' then Just [] else Nothing
-matchExpressions (HoleB i) (B i') = if i == i' then Just [] else Nothing
-matchExpressions (HoleFree n) (Free n') = if n == n' then Just [] else Nothing
-matchExpressions (Hole i) expr = Just [(i, expr)]-- IMPROVEMENT - currently doesn't check that expr is a term (as now have removed constant types)
-matchExpressions _ _ = Nothing
+matchExpressions (HoleCon s) (Con s') = if s == s' then return [] else mzero
+matchExpressions (HoleB i) (B i') = if i == i' then return [] else mzero
+matchExpressions (HoleFree n) (Free n') = if n == n' then return [] else mzero
+matchExpressions (Hole i) expr = return [(i, expr)]-- IMPROVEMENT - currently doesn't check that expr is a term (as now have removed constant types)
+matchExpressions _ _ = mzero
 
 -- Check whether the non-hole parts of the expressions match
 basicMatchCheck :: HoleExpr -> Expr -> Bool
@@ -127,15 +127,15 @@ getHoleDirections _ = []
 
 -- Takes a HoleExpr and directions to a hole and instantiates the
 -- hole with a given expr
-instantiateOneHole :: HoleExpr -> ExprDirections -> Expr -> Maybe HoleExpr
-instantiateOneHole (Hole _) [] e = Just $ exprToHoleExpr e
+instantiateOneHole :: (MonadPlus m) => HoleExpr -> ExprDirections -> Expr -> m HoleExpr
+instantiateOneHole (Hole _) [] e = return $ exprToHoleExpr e
 instantiateOneHole (HoleApp x y) (GoLeft:rest) e = do
                                 newx <- instantiateOneHole x rest e
-                                Just $ HoleApp newx y
+                                return $ HoleApp newx y
 instantiateOneHole (HoleApp x y) (GoRight:rest) e = do
                                 newy <- instantiateOneHole y rest e
-                                Just $ HoleApp x newy
+                                return $ HoleApp x newy
 instantiateOneHole (HoleAbs nm (HoleSc x)) (Enter:rest) e = do
                                 newx <- instantiateOneHole x rest e
-                                Just $ HoleAbs nm (HoleSc newx)
-instantiateOneHole _ _ _ = Nothing
+                                return $ HoleAbs nm (HoleSc newx)
+instantiateOneHole _ _ _ = mzero

--- a/src/Robot/MathematicianMonad.hs
+++ b/src/Robot/MathematicianMonad.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Robot.MathematicianMonad where
+
+import Robot.AutomationData
+import Robot.History
+import Robot.TableauFoundation
+
+import Control.Monad.State
+import GHC.Generics
+
+-- | The state we have in the monad is called MathematicianState
+data MathematicianState = MathematicianState
+    { returnFreshName :: Int,
+      -- ^ An integer larger than all the names of free variables.
+      -- ready to be used as a new name
+      returnAutData :: AutData,
+      returnHistory :: History }
+      deriving (Show, Read, Generic)
+
+-- | The Mathematician monad combines State and Maybe capabilities
+type Mathematician = StateT MathematicianState Maybe
+
+-- | Get a fresh name and increment the counter
+getFreshName :: Mathematician Int
+getFreshName = do
+    state <- get
+    let freshName = returnFreshName state
+    put $ state { returnFreshName = freshName + 1 }
+    return freshName
+
+getAutData :: Mathematician AutData
+getAutData = do
+    state <- get
+    return $ returnAutData state
+
+putAutData :: AutData -> Mathematician ()
+putAutData autData = do
+    state <- get
+    put $ state { returnAutData = autData }
+
+-- | Function to be called thus when a move is complete:
+-- result tab
+-- This is to ensure the tableau is added to the history
+result :: Tableau -> Mathematician Tableau
+result tab = do
+    state <- get
+    let history = returnHistory state
+    let present = HistoryItem tab (returnAutData state)
+    put $ state { returnHistory = history :=> present }
+    return tab
+
+getHistory :: Mathematician History
+getHistory = do
+    state <- get
+    return $ returnHistory state

--- a/src/Robot/MathematicianMonad.hs
+++ b/src/Robot/MathematicianMonad.hs
@@ -8,6 +8,7 @@ import Robot.TableauFoundation
 
 import Control.Monad.State
 import GHC.Generics
+import Data.Aeson (FromJSON, ToJSON)
 
 -- | The state we have in the monad is called MathematicianState
 data MathematicianState = MathematicianState
@@ -17,6 +18,9 @@ data MathematicianState = MathematicianState
       returnAutData :: AutData,
       returnHistory :: History }
       deriving (Show, Read, Generic)
+
+instance ToJSON MathematicianState
+instance FromJSON MathematicianState
 
 -- | The Mathematician monad combines State and Maybe capabilities
 type Mathematician = StateT MathematicianState Maybe
@@ -64,3 +68,9 @@ getHistory :: Mathematician History
 getHistory = do
     state <- get
     return $ returnHistory state
+
+baseMathematicianState :: MathematicianState
+baseMathematicianState = MathematicianState 1 startAutData NoHistory
+
+runMathematician :: Mathematician a -> MathematicianState -> Maybe (a, MathematicianState)
+runMathematician = runStateT

--- a/src/Robot/MathematicianMonad.hs
+++ b/src/Robot/MathematicianMonad.hs
@@ -21,6 +21,11 @@ data MathematicianState = MathematicianState
 -- | The Mathematician monad combines State and Maybe capabilities
 type Mathematician = StateT MathematicianState Maybe
 
+-- | Lifting function mainly used to turn Maybes into Mathematicians
+liftMaybe :: (MonadPlus m) => Maybe a -> m a
+liftMaybe (Just x) = return x
+liftMaybe Nothing = mzero
+
 -- | Get a fresh name and increment the counter
 getFreshName :: Mathematician Int
 getFreshName = do
@@ -38,6 +43,11 @@ putAutData :: AutData -> Mathematician ()
 putAutData autData = do
     state <- get
     put $ state { returnAutData = autData }
+
+updateAutData :: (AutData -> AutData) -> Mathematician ()
+updateAutData f = do
+    autData <- getAutData
+    putAutData $ f autData
 
 -- | Function to be called thus when a move is complete:
 -- result tab

--- a/src/Robot/Poset.hs
+++ b/src/Robot/Poset.hs
@@ -48,7 +48,7 @@ transitivelyCloseCounterExamples (Poset set rel) =
   let counterExamples = [(x, y, z) | x <- set, y <- set, z <- set, (((x,y) `elem` rel) && ((y,z) `elem` rel)) && (not ((x, z) `elem` rel))]
   in map (\(x, y, z) -> (x, z)) (nub counterExamples)
 
--- | Takes a Poset and try to extend it to a genuine maMaybethematical poset which is transitively closed
+-- | Takes a Poset and try to extend it to a genuine mathematical poset which is transitively closed
 -- We work in a monad that is an instance of MonadPlus to allow for failure
 transitivelyClose :: (Eq a, MonadPlus m) => Poset a -> m (Poset a)
 transitivelyClose poset =

--- a/src/Robot/Poset.hs
+++ b/src/Robot/Poset.hs
@@ -7,6 +7,7 @@ module Robot.Poset where
 import Data.List
 import Debug.Trace
 import GHC.Generics
+import Control.Monad
 import Data.Aeson (FromJSON, ToJSON, decode, toJSON)
 
 -- | Poset type to store information about quantification order. Probably very inefficient for now, but this can be optimised I'm sure
@@ -47,22 +48,28 @@ transitivelyCloseCounterExamples (Poset set rel) =
   let counterExamples = [(x, y, z) | x <- set, y <- set, z <- set, (((x,y) `elem` rel) && ((y,z) `elem` rel)) && (not ((x, z) `elem` rel))]
   in map (\(x, y, z) -> (x, z)) (nub counterExamples)
 
--- | Takes a Poset and try to extend it to a genuine mathematical poset which is transitively closed
-transitivelyClose :: (Eq a) => Poset a -> Maybe (Poset a)
+-- | Takes a Poset and try to extend it to a genuine maMaybethematical poset which is transitively closed
+-- We work in a monad that is an instance of MonadPlus to allow for failure
+transitivelyClose :: (Eq a, MonadPlus m) => Poset a -> m (Poset a)
 transitivelyClose poset =
   let witnesses = transitivelyCloseCounterExamples poset
   in
-    if witnesses == [] then (if isRealPoset poset then Just poset else Nothing)
+    if witnesses == [] then (if isRealPoset poset then return poset else mzero)
     else
       let (Poset set rel) = poset
           newPoset = Poset set (witnesses ++ rel)
-      in if isAsymmetric newPoset then transitivelyClose newPoset else Nothing
+      in if isAsymmetric newPoset then transitivelyClose newPoset else mzero
 
--- | Adds (a, b) to relation. If the result is not a Poset, returns Nothing.
-addRel :: (Eq a) => Poset a -> (a,a) -> Maybe (Poset a)
+-- | Adds (a, b) to relation.
+-- We work in a monad that is an instance of MonadPlus to allow for failure
+-- If the result is not a Poset, fails.
+addRel :: (Eq a, MonadPlus m) => Poset a -> (a,a) -> m (Poset a)
 addRel (Poset set rel) (x, y) = transitivelyClose (Poset set ((x,y):rel))
 
-addRels :: (Eq a) => Poset a -> [(a, a)] -> Maybe (Poset a)
+-- | Adds (a, b) to relation.
+-- We work in a monad that is an instance of MonadPlus to allow for failure
+-- If the result is not a Poset, fails.
+addRels :: (Eq a, MonadPlus m) => Poset a -> [(a, a)] -> m (Poset a)
 addRels (Poset set rel) toAdd = transitivelyClose (Poset set (toAdd ++ rel))
 
 -- | isBefore poset a b = True only when a < b in the poset

--- a/src/Robot/SubtaskLibrary.hs
+++ b/src/Robot/SubtaskLibrary.hs
@@ -7,6 +7,7 @@ import Robot.Subtasks
 import Robot.TableauFoundation
 import Robot.BasicMoves
 import Robot.AutomationData
+import Robot.MathematicianMonad
 
 import Data.Function
 import Data.Maybe
@@ -47,11 +48,12 @@ subtaskSearch index subtask@(Subtask subtaskType exprID pattern) =
 
 -- Given a destroy task which specifies an expression,
 -- Attempt to achieve the subtask using results from the index
-attemptDestroySubtask :: Index -> Subtask -> AutData -> Move
-attemptDestroySubtask index task@(Subtask subtaskType exprID pattern) autData tab = do
+attemptDestroySubtask :: Index -> Subtask -> Move
+attemptDestroySubtask index task@(Subtask subtaskType exprID pattern) tab = do
+    autData <- getAutData
     guard $ subtaskTypeToSubtaskClass subtaskType == Destroy
     let exprType = subtaskTypeToExprType subtaskType
-    eid <- exprID
+    eid <- liftMaybe exprID
     address <- case exprType of
         H -> getHypFromID eid autData
         T -> getTargFromID eid autData
@@ -59,7 +61,7 @@ attemptDestroySubtask index task@(Subtask subtaskType exprID pattern) autData ta
     let invoker = case exprType of
             H -> libEquivHyp
             T -> libEquivTarg
-    listToMaybe $ mapMaybe (\(EquivalenceValue result pair) ->
+    liftMaybe $ listToMaybe $ mapMaybe (\(EquivalenceValue result pair) ->
         invoker result pair address tab) equivalences
 
 -- Intersection and union properties

--- a/src/Robot/SubtaskLibrary.hs
+++ b/src/Robot/SubtaskLibrary.hs
@@ -63,8 +63,8 @@ attemptDestroySubtask index task@(Subtask subtaskType exprID pattern) tab = do
             H -> libEquivHyp
             T -> libEquivTarg
     guard $ not $ null equivalences
-    foldl1 (<|>) $ map (\(EquivalenceValue result pair) ->
-        invoker result pair address tab) equivalences
+    foldl1 (<|>) $ map (\(EquivalenceValue res pair) ->
+        invoker res pair address tab) equivalences
 
 -- Intersection and union properties
 

--- a/src/Robot/SubtaskLibrary.hs
+++ b/src/Robot/SubtaskLibrary.hs
@@ -12,6 +12,7 @@ import Robot.MathematicianMonad
 import Data.Function
 import Data.Maybe
 import Control.Monad
+import Control.Applicative
 
 import qualified Data.HashMap.Lazy as M
 import Data.Hashable
@@ -61,7 +62,8 @@ attemptDestroySubtask index task@(Subtask subtaskType exprID pattern) tab = do
     let invoker = case exprType of
             H -> libEquivHyp
             T -> libEquivTarg
-    liftMaybe $ listToMaybe $ mapMaybe (\(EquivalenceValue result pair) ->
+    guard $ not $ null equivalences
+    foldl1 (<|>) $ map (\(EquivalenceValue result pair) ->
         invoker result pair address tab) equivalences
 
 -- Intersection and union properties

--- a/src/Robot/TableauFoundation.hs
+++ b/src/Robot/TableauFoundation.hs
@@ -52,6 +52,10 @@ data Tableau = Tableau {getQZone :: QZone,
                         getRootBox :: Box Expr}
                         deriving (Eq, Read, Show, Generic)
 
+-- Create a tableau with just one given target
+exprToTab :: Expr -> Tableau
+exprToTab e = Tableau (Poset [] []) (Box [] [PureTarg e])
+
 -- Enum data type: Targets or Hypotheses
 data ExprType = T | H
 

--- a/src/Robot/TableauFoundation.hs
+++ b/src/Robot/TableauFoundation.hs
@@ -2,6 +2,16 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# OPTIONS -Wno-unused-imports #-}
 
+{-
+  A lot of the functions here have type (MonadPlus m) => ... -> m (Something)
+  Originally the types where just ... -> Maybe Something
+  The new types are more general, making the functions more versatile
+  If you want you can just think of m being Maybe when you read the code
+  (Maybe is an instance of the MonadPlus type class)
+  The reason for this change is so the functions can be used in the
+  Mathematician monad, which is also an instance of MonadPlus.
+-}
+
 module Robot.TableauFoundation where
 
 import Robot.Poset
@@ -12,6 +22,7 @@ import qualified Data.HashMap.Strict as M
 import Data.List
 import GHC.Generics
 import Data.Aeson (FromJSON, ToJSON, decode, toJSON)
+import Control.Monad
 
 -- <<<< TYPES DEFINING WHAT A TABLEAU IS >>>>
 
@@ -84,28 +95,28 @@ type BoxZipper a = (Box a, [BoxCrumb a])
 type BoxNumber = [Int]
 
 -- | Follows the directions specified by a BoxNumber From a BoxZipper
-toBoxNumberFromZipper :: BoxNumber -> BoxZipper a -> Maybe (BoxZipper a)
-toBoxNumberFromZipper [] zipper = Just zipper
+toBoxNumberFromZipper :: (MonadPlus m) => BoxNumber -> BoxZipper a -> m (BoxZipper a)
+toBoxNumberFromZipper [] zipper = return zipper
 toBoxNumberFromZipper (nextBoxInd:rest) (Box hyps targs, crumbs)
-  | nextBoxInd < 0 || nextBoxInd >= length targs = Nothing
+  | nextBoxInd < 0 || nextBoxInd >= length targs = mzero
   | otherwise = let (as, ourTarg:bs) = splitAt nextBoxInd targs in case ourTarg of
-      PureTarg _ -> Nothing
+      PureTarg _ -> mzero
       BoxTarg newBox -> let
         newCrumb = Crumb hyps as bs
-        newZipper = Just (newBox, newCrumb:crumbs)
+        newZipper = return (newBox, newCrumb:crumbs)
         in newZipper >>= toBoxNumberFromZipper rest
 
 -- | Follows the directions to a BoxNumber from the root
-toBoxNumberFromRoot :: BoxNumber -> Box a -> Maybe (BoxZipper a)
+toBoxNumberFromRoot :: (MonadPlus m) => BoxNumber -> Box a -> m (BoxZipper a)
 toBoxNumberFromRoot boxNumber box = toBoxNumberFromZipper boxNumber (box, [])
 
 -- | Takes a BoxZipper and "goes up" a single level
-goUp :: BoxZipper a -> Maybe (BoxZipper a)
-goUp (_, []) = Nothing
+goUp :: (MonadPlus m) => BoxZipper a -> m (BoxZipper a)
+goUp (_, []) = mzero
 goUp (box, crumb:rest) = let
   Crumb hyps aTargs bTargs = crumb
   newBox = Box hyps (aTargs ++ [BoxTarg box] ++ bTargs)
-  in Just (newBox, rest)
+  in return (newBox, rest)
 
 -- | Takes a BoxZipper and entirely unzips it, returning the whole Box
 unzipBox :: BoxZipper a -> Box a
@@ -115,30 +126,30 @@ unzipBox zipper = let Just newZipper = goUp zipper
 
 
 -- | Gets the hypInd-th hyp from a BoxZipper, if it exists
-getHypInZipper :: Int -> BoxZipper a -> Maybe a
+getHypInZipper :: (MonadPlus m) => Int -> BoxZipper a -> m a
 getHypInZipper hypInd (Box hyps _, _)
-  | hypInd < 0 || hypInd >= length hyps = Nothing
-  | otherwise = Just $ hyps !! hypInd
+  | hypInd < 0 || hypInd >= length hyps = mzero
+  | otherwise = return $ hyps !! hypInd
 
-getPureTargInZipper :: Int -> BoxZipper a -> Maybe a
+getPureTargInZipper :: (MonadPlus m) => Int -> BoxZipper a -> m a
 getPureTargInZipper targInd (Box _ targs, _)
-  | targInd < 0 || targInd >= length targs = Nothing
+  | targInd < 0 || targInd >= length targs = mzero
   | otherwise = case targs !! targInd of
-    BoxTarg _ -> Nothing
-    PureTarg targ -> Just targ
+    BoxTarg _ -> mzero
+    PureTarg targ -> return targ
 
-getBoxTargInZipper :: Int -> BoxZipper a -> Maybe (Box a)
+getBoxTargInZipper :: (MonadPlus m) => Int -> BoxZipper a -> m (Box a)
 getBoxTargInZipper targInd (Box _ targs, _)
-  | targInd < 0 || targInd >= length targs = Nothing
+  | targInd < 0 || targInd >= length targs = mzero
   | otherwise = case targs !! targInd of
-    BoxTarg box -> Just box
-    PureTarg _ -> Nothing
+    BoxTarg box -> return box
+    PureTarg _ -> mzero
 
 -- | Gets the box given by a BoxNumber from a given "root" box
-getBox :: BoxNumber -> Box a -> Maybe (Box a)
+getBox :: (MonadPlus m) => BoxNumber -> Box a -> m (Box a)
 getBox boxNumber rootBox = case toBoxNumberFromRoot boxNumber rootBox of
-  Just (box, _) -> Just box
-  Nothing -> Nothing
+  Just (box, _) -> return box
+  Nothing -> mzero
 
 -- | Adds a hypothesis to a BoxZipper
 addHypToZipper :: a -> BoxZipper a -> BoxZipper a
@@ -151,62 +162,62 @@ addBoxTargToZipper :: Box a -> BoxZipper a -> BoxZipper a
 addBoxTargToZipper targ (Box hyps targs, crumbs) = (Box hyps (targs++[BoxTarg targ]), crumbs)
 
 -- | Removes the hypInd-th hypothesis from a BoxZipper
-removeHypFromZipper :: Int -> BoxZipper a -> Maybe (BoxZipper a)
+removeHypFromZipper :: (MonadPlus m) => Int -> BoxZipper a -> m (BoxZipper a)
 removeHypFromZipper hypInd (Box hyps targs, crumbs)
-  | hypInd < 0 || hypInd >= length hyps = Nothing
+  | hypInd < 0 || hypInd >= length hyps = mzero
   | otherwise = let (as, ourHyp:bs) = splitAt hypInd hyps
-    in Just (Box (as++bs) targs, crumbs)
+    in return (Box (as++bs) targs, crumbs)
 
-removeTargFromZipper :: Int -> BoxZipper a -> Maybe (BoxZipper a)
+removeTargFromZipper :: (MonadPlus m) => Int -> BoxZipper a -> m (BoxZipper a)
 removeTargFromZipper targInd (Box hyps targs, crumbs)
-  | targInd < 0 || targInd >= length targs = Nothing
+  | targInd < 0 || targInd >= length targs = mzero
   | otherwise = let (as, ourTarg:bs) = splitAt targInd targs
-    in Just (Box hyps (as++bs), crumbs)
+    in return (Box hyps (as++bs), crumbs)
 
 -- | Updates the hypInd-th hypothesis in a BoxZipper
-updateHypInZipper :: Int -> a -> BoxZipper a -> Maybe (BoxZipper a)
+updateHypInZipper :: (MonadPlus m) => Int -> a -> BoxZipper a -> m (BoxZipper a)
 updateHypInZipper hypInd newHyp (Box hyps targs, crumbs)
-  | hypInd < 0 || hypInd >= length hyps = Nothing
+  | hypInd < 0 || hypInd >= length hyps = mzero
   | otherwise = let (as, ourHyp:bs) = splitAt hypInd hyps
-    in Just (Box (as++newHyp:bs) targs, crumbs)
+    in return (Box (as++newHyp:bs) targs, crumbs)
 
-updatePureTargInZipper :: Int -> a -> BoxZipper a -> Maybe (BoxZipper a)
+updatePureTargInZipper :: (MonadPlus m) => Int -> a -> BoxZipper a -> m (BoxZipper a)
 updatePureTargInZipper targInd newTarg (Box hyps targs, crumbs)
-  | targInd < 0 || targInd >= length targs = Nothing
+  | targInd < 0 || targInd >= length targs = mzero
   | otherwise = let (as, ourTarg:bs) = splitAt targInd targs
     in case ourTarg of
-      PureTarg _ -> Just (Box hyps (as++PureTarg newTarg:bs), crumbs)
-      BoxTarg _ -> Nothing
+      PureTarg _ -> return (Box hyps (as++PureTarg newTarg:bs), crumbs)
+      BoxTarg _ -> mzero
 
-updateBoxTargInZipper :: Int -> Box a -> BoxZipper a -> Maybe (BoxZipper a)
+updateBoxTargInZipper :: (MonadPlus m) => Int -> Box a -> BoxZipper a -> m (BoxZipper a)
 updateBoxTargInZipper targInd newTarg (Box hyps targs, crumbs)
-  | targInd < 0 || targInd >= length targs = Nothing
+  | targInd < 0 || targInd >= length targs = mzero
   | otherwise = let (as, ourTarg:bs) = splitAt targInd targs
     in case ourTarg of
-      BoxTarg _ -> Just (Box hyps (as++BoxTarg newTarg:bs), crumbs)
-      PureTarg _ -> Nothing
+      BoxTarg _ -> return (Box hyps (as++BoxTarg newTarg:bs), crumbs)
+      PureTarg _ -> mzero
 
 
 -- | Turns a PureTarg into a BoxTarg containing no hyps and a single targ
-pureToBoxTargZipper :: Int -> BoxZipper a -> Maybe (BoxZipper a)
+pureToBoxTargZipper :: (MonadPlus m) => Int -> BoxZipper a -> m (BoxZipper a)
 pureToBoxTargZipper targInd (Box hyps targs, crumbs)
-  | targInd < 0 || targInd >= length targs = Nothing
+  | targInd < 0 || targInd >= length targs = mzero
   | otherwise = let (as, ourTarg:bs) = splitAt targInd targs in
     case ourTarg of
-      BoxTarg _ -> Nothing
-      PureTarg targ -> Just (Box hyps (as ++ BoxTarg (Box [] [PureTarg targ]):bs), crumbs)
+      BoxTarg _ -> mzero
+      PureTarg targ -> return (Box hyps (as ++ BoxTarg (Box [] [PureTarg targ]):bs), crumbs)
 
 -- | Returns all the hypotheses in a box and its parents. These are the ones
 -- that can be used when trying to prove targets in this box.
-getHypsUsableInBoxNumber :: BoxNumber -> Box Expr -> Maybe [Expr]
-getHypsUsableInBoxNumber [] (Box rootHyps _) = Just rootHyps
+getHypsUsableInBoxNumber :: (MonadPlus m) => BoxNumber -> Box Expr -> m [Expr]
+getHypsUsableInBoxNumber [] (Box rootHyps _) = return rootHyps
 getHypsUsableInBoxNumber (nextBoxInd:rest) (Box rootHyps rootTargs)
-  | nextBoxInd < 0 || nextBoxInd >= length rootTargs = Nothing
+  | nextBoxInd < 0 || nextBoxInd >= length rootTargs = mzero
   | otherwise = case rootTargs !! nextBoxInd of
-      PureTarg _ -> Nothing
+      PureTarg _ -> mzero
       BoxTarg box -> do
         lowerHyps <- getHypsUsableInBoxNumber rest box
-        Just $ rootHyps ++ lowerHyps
+        return $ rootHyps ++ lowerHyps
 
 -- | Checks whether a boxNumber is a prefix of another
 -- i.e. (isPrefix a b) iff a is a parent of b
@@ -218,10 +229,10 @@ isPrefix (a:as) (b:bs) = a == b && isPrefix as bs
 -- | Given a list of BoxNumbers, returns them in an order s.t. parents come
 -- first then children. If this isn't possible (i.e. if two boxes are
 -- not parent/child to each other), returns Nothing
-orderBoxNumbers :: [BoxNumber] -> Maybe [BoxNumber]
+orderBoxNumbers :: (MonadPlus m) => [BoxNumber] -> m [BoxNumber]
 orderBoxNumbers boxNumbers = let
   sortedBoxNumbers = sortBy (\a b -> length a `compare` length b) boxNumbers
-  in if verifyPrefix [] (nub sortedBoxNumbers) then Just sortedBoxNumbers else Nothing
+  in if verifyPrefix [] (nub sortedBoxNumbers) then return sortedBoxNumbers else mzero
   where
     verifyPrefix :: BoxNumber -> [BoxNumber] -> Bool
     verifyPrefix _ [] = True
@@ -229,10 +240,10 @@ orderBoxNumbers boxNumbers = let
 
 -- | e.g. (getPrefixDiff [0,1,4,3] [0,1] = Just [4,3])
 -- getPrefixDiff [0,1,4,3] [0,1,3,0,0] = Nothing 
-getPrefixDiff :: BoxNumber -> BoxNumber -> Maybe BoxNumber
-getPrefixDiff longer [] = Just longer
-getPrefixDiff [] (a:_) = Nothing
-getPrefixDiff (a:as) (b:bs) = if a == b then getPrefixDiff as bs else Nothing
+getPrefixDiff :: (MonadPlus m) => BoxNumber -> BoxNumber -> m BoxNumber
+getPrefixDiff longer [] = return longer
+getPrefixDiff [] (a:_) = mzero
+getPrefixDiff (a:as) (b:bs) = if a == b then getPrefixDiff as bs else mzero
 
 -- | If the list of BoxNumber's provided can be linearly ordered then
 -- returns the list of directions that one would follow from the root
@@ -242,41 +253,47 @@ getPrefixDiff (a:as) (b:bs) = if a == b then getPrefixDiff as bs else Nothing
 -- which targs we're allowed to solve using the hyps from the given boxes)
 -- e.g. boxNumbersToDirections [([1,0,3], "bottom"),([1,0], "middle"),([], "root")]
 -- = Just ([([], "root"), ([1, 0], "middle"), ([3], "bottom")], [1,0,3])
-boxNumbersToDirections :: [(BoxNumber, a)] -> Maybe ([(BoxNumber, a)], BoxNumber)
+boxNumbersToDirections :: (MonadPlus m) => [(BoxNumber, a)] ->
+  m ([(BoxNumber, a)], BoxNumber)
 boxNumbersToDirections boxNumbersWithData = let
-  reverseSortedBoxNumbersWithData = sortBy (\b a -> length (fst a) `compare` length (fst b)) boxNumbersWithData
-  traverseBoxNumbers :: [(BoxNumber, a)] -> [(BoxNumber, a)] -> Maybe [(BoxNumber, a)]
-  traverseBoxNumbers trailSoFar [] = Just trailSoFar
-  traverseBoxNumbers trailSoFar [thisBox] = Just (thisBox:trailSoFar)
+  reverseSortedBoxNumbersWithData = sortBy
+    (\b a -> length (fst a) `compare` length (fst b)) boxNumbersWithData
+  traverseBoxNumbers :: (MonadPlus m) => [(BoxNumber, a)] -> [(BoxNumber, a)] ->
+    m [(BoxNumber, a)]
+  traverseBoxNumbers trailSoFar [] = return trailSoFar
+  traverseBoxNumbers trailSoFar [thisBox] = return (thisBox:trailSoFar)
   traverseBoxNumbers trailSoFar (thisBox:(nextBox:rest)) = -- thisBox is further down than nextBox
     case getPrefixDiff (fst thisBox) (fst nextBox) of
-      Nothing -> Nothing
+      Nothing -> mzero
       Just diff -> traverseBoxNumbers ((diff, snd thisBox):trailSoFar) (nextBox:rest)
   deepestBox = case map fst reverseSortedBoxNumbersWithData of
     [] -> []
     (a:_) -> a
   in do
     directions <- traverseBoxNumbers [] reverseSortedBoxNumbersWithData
-    Just (directions, deepestBox)
+    return (directions, deepestBox)
 
 -- | The same as above, but returns the shallowest box (useful because this
 -- tells us which hypotheses we can use in solving a list of targets)
-boxNumbersToDirectionsFlipped :: [(BoxNumber, a)] -> Maybe ([(BoxNumber, a)], BoxNumber)
+boxNumbersToDirectionsFlipped :: (MonadPlus m) => [(BoxNumber, a)] ->
+  m ([(BoxNumber, a)], BoxNumber)
 boxNumbersToDirectionsFlipped boxNumbersWithData = let
-  reverseSortedBoxNumbersWithData = sortBy (\b a -> length (fst a) `compare` length (fst b)) boxNumbersWithData
-  traverseBoxNumbers :: [(BoxNumber, a)] -> [(BoxNumber, a)] -> Maybe [(BoxNumber, a)]
-  traverseBoxNumbers trailSoFar [] = Just trailSoFar
-  traverseBoxNumbers trailSoFar [thisBox] = Just (thisBox:trailSoFar)
+  reverseSortedBoxNumbersWithData = sortBy
+    (\b a -> length (fst a) `compare` length (fst b)) boxNumbersWithData
+  traverseBoxNumbers :: (MonadPlus m) => [(BoxNumber, a)] -> [(BoxNumber, a)] ->
+    m [(BoxNumber, a)]
+  traverseBoxNumbers trailSoFar [] = return trailSoFar
+  traverseBoxNumbers trailSoFar [thisBox] = return (thisBox:trailSoFar)
   traverseBoxNumbers trailSoFar (thisBox:(nextBox:rest)) = -- thisBox is further down than nextBox
     case getPrefixDiff (fst thisBox) (fst nextBox) of
-      Nothing -> Nothing
+      Nothing -> mzero
       Just diff -> traverseBoxNumbers ((diff, snd thisBox):trailSoFar) (nextBox:rest)
   shallowestBox = case map fst (reverse reverseSortedBoxNumbersWithData) of
     [] -> []
     (a:_) -> a
   in do
     directions <- traverseBoxNumbers [] reverseSortedBoxNumbersWithData
-    Just (directions, shallowestBox)
+    return (directions, shallowestBox)
 
 
 -- | This function basically only exists to help removing hyps and targs.
@@ -284,21 +301,23 @@ boxNumbersToDirectionsFlipped boxNumbersWithData = let
 -- are broken by forcing the second argument to be decreasing.
 -- e.g. boxNumbersToDirectionsWithInt [([], 0), ([], 1), ([0,1],2), ([0,1],3)] =
 -- Just ([([], 1), ([], 0), ([0,1], 3), ([], 2)], [0,1])
-boxNumbersToDirectionsWithInt :: [(BoxNumber, Int)] -> Maybe ([(BoxNumber, Int)], BoxNumber)
+boxNumbersToDirectionsWithInt :: (MonadPlus m) => [(BoxNumber, Int)] ->
+  m ([(BoxNumber, Int)], BoxNumber)
 boxNumbersToDirectionsWithInt boxNumbersWithData = let
   reverseSortedBoxNumbersWithData = sortBy (\b a -> let
     firstCompare = length (fst a) `compare` length (fst b)
     in if firstCompare /= EQ then firstCompare else snd b `compare` snd a) boxNumbersWithData
-  traverseBoxNumbers :: [(BoxNumber, a)] -> [(BoxNumber, a)] -> Maybe [(BoxNumber, a)]
-  traverseBoxNumbers trailSoFar [] = Just trailSoFar
-  traverseBoxNumbers trailSoFar [thisBox] = Just (thisBox:trailSoFar)
+  traverseBoxNumbers :: (MonadPlus m) => [(BoxNumber, a)] -> [(BoxNumber, a)] ->
+    m [(BoxNumber, a)]
+  traverseBoxNumbers trailSoFar [] = return trailSoFar
+  traverseBoxNumbers trailSoFar [thisBox] = return (thisBox:trailSoFar)
   traverseBoxNumbers trailSoFar (thisBox:(nextBox:rest)) = -- thisBox is further down than nextBox
     case getPrefixDiff (fst thisBox) (fst nextBox) of
-      Nothing -> Nothing
+      Nothing -> mzero
       Just diff -> traverseBoxNumbers ((diff, snd thisBox):trailSoFar) (nextBox:rest)
   shallowestBox = case map fst (reverse reverseSortedBoxNumbersWithData) of
     [] -> []
     (a:_) -> a
   in do
     directions <- traverseBoxNumbers [] reverseSortedBoxNumbersWithData
-    Just (directions, shallowestBox)
+    return (directions, shallowestBox)

--- a/src/Robot/Testing.hs
+++ b/src/Robot/Testing.hs
@@ -371,6 +371,6 @@ s1 = "forall A, forall B, forall C, forall D, " ++
                 "and(forall x, implies(element_of(x, A), element_of(x, B)), " ++
                     "forall x, implies(element_of(x, intersection(A, B)), element_of(x, C)))), " ++
     "exists x, element_of(x, union(C, D)))"
-Just s1result = runMathematician (
+Just s1Result = runMathematician (
     stringToTab s1 >>= result >>= tidyEverything >>= peelExistentialTarg ([], 0)
     ) baseMathematicianState

--- a/src/Robot/Testing.hs
+++ b/src/Robot/Testing.hs
@@ -13,6 +13,7 @@ import Robot.BasicMoves
 import Robot.PPrinting
 import Robot.HoleExpr
 import Robot.Parser
+import Robot.Automation
 
 import Data.Maybe
 import Data.List

--- a/src/Robot/Testing.hs
+++ b/src/Robot/Testing.hs
@@ -14,6 +14,7 @@ import Robot.PPrinting
 import Robot.HoleExpr
 import Robot.Parser
 import Robot.Automation
+import Robot.MathematicianMonad
 
 import Data.Maybe
 import Data.List
@@ -22,14 +23,10 @@ import Debug.Trace
 
 -- <<< HELPER FUNCTIONS >>>
 
--- Create a tableau with just one given target
-exprToTab :: Expr -> Tableau
-exprToTab e = Tableau (Poset [] []) (Box [] [PureTarg e])
-
 -- | Parse a string for a single target as an expression then turn it into a Tableau as above
-stringToTab :: String -> Maybe Tableau
+stringToTab :: (MonadPlus m) => String -> m Tableau
 stringToTab s = do
-    e <- parseSimple parseExpr s
+    e <- liftMaybe $ parseSimple parseExpr s
     return $ exprToTab e
 
 -- <<< MOVE TESTING >>>
@@ -270,7 +267,7 @@ g1 = forall (Just $ ExternalName "X") (0) $
 
 gTab = exprToTab g1
 
-Just gResult = peelUniversalTarg ([], 0) gTab >>= peelUniversalTarg ([], 0) >>= peelUniversalTarg ([], 0) >>= peelUniversalTarg ([], 0) >>= peelUniversalTarg ([], 0) >>= peelUniversalTarg ([], 0)
+Just gResult = runMathematician (result gTab >>= peelUniversalTarg ([], 0) >>= peelUniversalTarg ([], 0) >>= peelUniversalTarg ([], 0) >>= peelUniversalTarg ([], 0) >>= peelUniversalTarg ([], 0) >>= peelUniversalTarg ([], 0)
     >>= tidyImplInTarg ([], 0) >>= tidyAndInHyp ([], 0) >>= tidyAndInHyp ([], 0) >>= tidyAndInHyp ([], 0) >>= tidyAndInHyp ([], 0) >>= tidyAndInHyp ([], 0)
     >>= libEquivTarg continuousDef (0, 1) ([], 0) >>= peelUniversalTarg ([], 0)
     >>= tidyImplInTarg ([], 0) >>= peelUniversalTarg ([], 0) >>= tidyImplInTarg ([], 0)
@@ -291,6 +288,7 @@ Just gResult = peelUniversalTarg ([], 0) gTab >>= peelUniversalTarg ([], 0) >>= 
     >>= rawModusPonens ([1,1,1,1,1,1], 3) ([1,1,1,1,1,1], 1)
     >>= instantiateExistential "a" "n" >>= libForwardReasoning triIneq
     >>= instantiateExistential "b" "theta"
+    ) baseMathematicianState
 
 at1 = exists (Just $ ExternalName "x") 0 (forall (Just $ ExternalName "y") 0 (exists (Just $ ExternalName "z") 1 (Eq (Free 0) (Free 1))))
 aBox = Box [] [PureTarg at1]
@@ -373,4 +371,6 @@ s1 = "forall A, forall B, forall C, forall D, " ++
                 "and(forall x, implies(element_of(x, A), element_of(x, B)), " ++
                     "forall x, implies(element_of(x, intersection(A, B)), element_of(x, C)))), " ++
     "exists x, element_of(x, union(C, D)))"
-Just s1Tab = stringToTab s1 >>= tidyEverything >>= peelExistentialTarg ([], 0)
+Just s1result = runMathematician (
+    stringToTab s1 >>= result >>= tidyEverything >>= peelExistentialTarg ([], 0)
+    ) baseMathematicianState

--- a/src/static/problem/problem.html
+++ b/src/static/problem/problem.html
@@ -45,7 +45,7 @@
 <button class="action_button" id="commitToHyp" onclick="actionButton(event)">Commit to hyp</button>
 <button class="action_button" id="modusPonens" onclick="actionButton(event)">Modus ponens</button>
 <button class="action_button" id="modusPonensRaw" onclick="actionButton(event)">Modus ponens raw</button>
-<button class="action_button" id="undo" onclick="undo()">Undo</button>
+<button class="action_button" id="undo" onclick="actionButton(event)">Undo</button>
 
 
 <input type="text" id="manual_function_input" oninput="manualFunctionInput(event)">

--- a/src/static/problem/script.js
+++ b/src/static/problem/script.js
@@ -93,6 +93,7 @@ setUpOnLoad = function(){
 // 1 - target
 // 2 - text input
 const argsToWaitForInfo = {
+	"undo": [],
 	"peelUniversalTarg": [1],
 	"peelExistentialTarg": [1],
 	"peelUniversalHyp": [0],
@@ -136,20 +137,6 @@ resetGlobalClickState = function(){
 		let expr = targs[i]
 		expr.style.backgroundColor = "white"
 	}
-}
-
-function undo() {
-	if (globalProblemState && globalProblemState.getProofHistory) {
-		// newest problem state at head of proof history
-		[tab, autData, tabHtml] = globalProblemState.getProofHistory.shift();
-		globalProblemState.getTab = tab;
-		globalProblemState.getAutData = autData;
-		globalProblemState.getTabHtml = tabHtml;
-
-		showProblemState();
-		MathJax.typeset();
-	}
-	resetGlobalClickState();
 }
 
 manualFunctionInput = function(e){


### PR DESCRIPTION
The Mathematician monad is now the main monad for writing moves (moves have a type Tableau->Mathematician Tableau).
In this merge request, almost all the moves have been moved over to use this new monad. The moves applying library results are an exception, but these will need to be rewritten anyway. Note these changes haven't had specific tests written, the fact that the interface works with the new code is taken to be good evidence that nothing is broken.